### PR TITLE
Update main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,122 +1,220 @@
 # bt-target
  
-Dependencies: https://github.com/mkafrin/PolyZone
+Dependencies:
+* PolyZone: https://github.com/mkafrin/PolyZone
+* Linden Inventory (Latest version): https://github.com/thelindat/linden_inventory/
+* Linden ESX Legacy (es_extended) (Latest): https://github.com/thelindat/es_extended AND follow instructions
 
-## Updated functionality
-My fork of bt-target includes the following options:
-* Pass all data through to the target event in the data table 
-* Add vehicle bone support
-* Disable the ability to aima/attack while in interactive mode
-* Check overall job grade to access the menu 
-* Check individual option job grades 
-
-
-```lua
-Citizen.CreateThread(function()
-    local coffee = {
-        690372739,
-    }
-    AddTargetModel(coffee, {
-        options = {
-            {
-                event = "coffeeevent",
-                icon = "fas fa-coffee",
-                label = "Coffee",
-                item = "coffee",
-                price = 5,
-                grade = 1,  --This defines the minimum grade of the jobs defined below to access this option
-                anything_else = "You can pass any data through this table",
-                mytable = { name = 'mytable', description = 'including another table'},
-            },
-        },
-        job = {["all"] = grade { grade = 0}} -- Allow you to define overall grade requirements to access any option within this interaction
-        distance = 2.5
-    })
-end)
-
-RegisterNetEvent('coffeeevent')
-AddEventHandler('coffeeevent',function(data)
-    print("You purchased a " .. data.item .. " for $" .. data.price .. ". Enjoy!")
-end)
-```
 
 Icons: https://fontawesome.com/
 
-Here a simple target tracking script that tracks where your player is looking at. Coords and models can be used. You can add multiple payphone models for example and when your player looks at it. It activates the UI to trigger an event. Polyzones can be used also. Its uses 0.00 ms (0.16% CPU Time) when idle. This can be used in multiple scripts to help with optimisation. Press ALT to activate. Using RegisterKeyMapping removes the need of checking if key has been pressed in a thread and players can customise the keybind in the ESCAPE menu. You can also create multiple options per target. Read the example to learn how to use it.
+## Version noms 0.2
+* Added support for networked Entity bt-targets - you can attach a bt-target to a spawned entity and it'll be removed with that entity when it gets deleted, and the target only applies to that specific entity
+* Added support for EntityZones - spawn a zone around an entity which can be interacted with 
+* Ability to pass any parameters through the bt-target option (see examples)
+* Pass the entity interacted with through the event
+* Moved job/grade checks to a per-option basis, and made it optional so you don't have to define it (see examples)
+* Added a `required_item` check that works with Linden Inventory exports to check if you have an item before showing an option (see examples)
+* Added a `canInteract()` function (see examples)
 
-Example: 
+## Version noms 0.1
+My fork of bt-target includes the following options:
+* Pass all data through to the target event in the data table 
+* Add vehicle bone support
+* Disable the ability to aim/attack while in interactive mode
+* Check overall job grade to access the menu 
+* Check individual option job grades 
+
+## Installation instructions
+Installation is very straightforward but as we use a few custom imports for performance you'll want to include them yourself:
+In `es_extended\imports.lua` Add the following to the bottom of the file (if it does not already exist):
+```lua
+------------------------------------------------------------------------
+-- SHARED
+------------------------------------------------------------------------
+local Intervals = {}
+local CreateInterval = function(name, interval, action, clear)
+	local self = {interval = interval}
+	CreateThread(function()
+		local name, action, clear = name, action, clear
+		repeat
+			action()
+			Citizen.Wait(self.interval)
+		until self.interval == -1
+		if clear then clear() end
+		Intervals[name] = nil
+	end)
+	return self
+end
+
+SetInterval = function(name, interval, action, clear)
+	if Intervals[name] and interval then Intervals[name].interval = interval
+	else
+		Intervals[name] = CreateInterval(name, interval, action, clear)
+	end
+end
+
+ClearInterval = function(name)
+	Intervals[name].interval = -1
+end
+```
+
+## Examples 
+
+### Passing Item Data / AddTargetModel 
+```lua
+
+local coffee = {
+    690372739,
+}
+exports['bt-target']:AddTargetModel(coffee, {
+    options = {
+        {
+            event = "coffee:buy",
+            icon = "fas fa-coffee",
+            label = "Coffee",
+            item = "coffee",
+            price = 5,
+        },
+    },
+    distance = 2.5
+})
+
+
+RegisterNetEvent('coffee:buy')
+AddEventHandler('coffee:buy',function(data)
+    ESX.ShowNotification("You purchased a " .. data.item .. " for $" .. data.price .. ". Enjoy!")
+    -- server event to buy the item here
+end)
+```
+`AddTargetModel` requires a table of model hashes to function correctly. You can use the direct hash number: `690372739` or direct object name with backticks: ``prop_vend_coffe_01``. 
+Define a table like: 
+```lua 
+local coffee = {
+    `prop_vend_coffe_01`,
+    `p_ld_coffee_vend_01`
+}
+```
+
+
+### Checking job / BoxZone
 
 ```lua
-Citizen.CreateThread(function()
-    local peds = {
-        `a_f_m_bevhills_02`,
-    }
-    AddTargetModel(peds, {
-        options = {
-            {
-                event = "Random 1event",
-                icon = "fas fa-dumpster",
-                label = "Random 1",
-            },
-            {
-                event = "Random 2event",
-                icon = "fas fa-dumpster",
-                label = "Random 2",
-                grade = 1,
-            },
-            {
-                event = "Random 3event",
-                icon = "fas fa-dumpster",
-                label = "Random 3",
-                grade = 2,
-            },
-            {
-                event = "Random 4event",
-                icon = "fas fa-dumpster",
-                label = "Random 4",
-                grade = 3,
-            },
-        },
-        job = {["garbage"] = {grade = 0}}
-        distance = 2.5
-    })
-
-    local coffee = {
-        690372739,
-    }
-    AddTargetModel(coffee, {
-        options = {
-            {
-                event = "coffeeevent",
-                icon = "fas fa-coffee",
-                label = "Coffee",
-            },
-        },
-        job = {["all"] = {grade = 0}}
-        distance = 2.5
-    })
-    
-    AddBoxZone("PoliceDuty", vector3(441.79, -982.07, 30.69), 0.4, 0.6, {
-	name="PoliceDuty",
-	heading=91,
-	debugPoly=false,
-	minZ=30.79,
-	maxZ=30.99
+exports['bt-target']:AddBoxZone("MissionRowDutyClipboard", vector3(441.7989, -982.0529, 30.67834), 0.45, 0.35, {
+    name="MissionRowDutyClipboard",
+    heading=11.0,
+    debugPoly=false,
+    minZ=30.77834,
+    maxZ=30.87834,
     }, {
         options = {
             {
-                event = "signon",
-                icon = "far fa-clipboard",
-                label = "Sign On",
+                event = "qrp_duty:goOnDuty",
+                icon = "fas fa-sign-in-alt",
+                label = "Sign In",
+                job = "police",
             },
             {
-                event = "signoff",
-                icon = "far fa-clipboard",
-                label = "Sign Off",
+                event = "qrp_duty:goOffDuty",
+                icon = "fas fa-sign-out-alt",
+                label = "Sign Out",
+                job = "police",
             },
         },
-        job = {["police"] = {grade = 0}, ["ambulance"] = { grade = 0}, ["mechanic"] = {grade =0 }},
-        distance = 1.5
-    })
-end)
+        distance = 3.5
+})
+```
+In this example I'm defining police as a straight string to check if the player interacting has that job before showing the option. You can also define it as `[key] = value` pairs for grade, for example:
+```lua
+job = {
+    ["police"] = 5, -- minimum grade required to see this option
+    ["ambulance"] = 0,
+}
+```
+
+### Removing Zones
+You can and SHOULD remove zones in various situations, as a rule I tend to remove a zone with the same name before creating one to prevent clutter, and it helps if you're using debugPoly. 
+```lua
+exports['bt-target']:RemoveZone("MissionRowDutyClipboard")
+```
+Just make sure you're using the exact name of the zone you defined.
+
+### CanInteract / EntityZone
+In this example we're making a specifc zone around an entity that was created. This can help if you can't interact with a particular entity, but also don't have a static location to define.
+The EntityZone is typically removed with the entity. 
+
+The `canInteract()` function defined here allows you to do any particular checks you want to be executed at the time of interaction, in this instance, it checks if the plant has a statebag defined for growth that is higher than or equal to 100.
+You can do any check you want as long as you return true or false. 
+
+```lua
+local playerPed = PlayerPedId()
+local coords = GetEntityCoords(playerPed)
+model = `prop_plant_fern_02a`
+RequestModel(model)
+while not HasModelLoaded(model) do
+    Citizen.Wait(50)
+end
+local plant = CreateObject(model, coords.x, coords.y, coords.z, true, true)
+Citizen.Wait(50)
+PlaceObjectOnGroundProperly(plant)
+SetEntityInvincible(plant, true)
+
+exports['bt-target']:AddEntityZone("potato-growing-"..plant, plant, {
+    name = "potato-growing-"..plant,
+    heading=GetEntityHeading(plant),
+    debugPoly=false,
+}, {
+    options = {
+    {
+        event = "farming:harvestPlant",
+        icon = "fa-solid fa-scythe",
+        label = "Harvest potato",
+        plant = plant,
+        job = "farmer",
+        canInteract = function()
+            if Entity(plant).state.growth >= 100 then 
+                return true
+            else 
+                return false
+            end 
+        end,
+    },
+},
+    distance = 3.5
+})
+```
+
+### AddTargetEntity
+You can also define an entity target that only that entity will have the interaction. This is very simular to EntityZone except attached to the network entity instead of a static zone.
+
+```lua
+exports['bt-target']:AddTargetEntity(NetworkGetNetworkIdFromEntity(vehicle), {
+    options = {
+        {
+            event = "postop:getPackage",
+            icon = "fa-solid fa-box-circle-check",
+            label = "Get Package",
+            owner = NetworkGetNetworkIdFromEntity(PlayerPedId()),
+            job = "postop",
+        },
+    },
+    distance = 3.0
+})
+
+
+### AddTargetBone
+Use this in conjunction with the bone index in the `config.lua` file to define bones you would like to interact with on a vehicle.
+
+```lua
+	exports['bt-target']:AddTargetBone({"boot"}, {
+	options = {
+		{
+			event = "qrp_vehicle:toggleVehicleDoor",
+			icon = "fas fa-door-open",
+			label = "Toggle Boot",
+			door = 5,
+		},
+	},
+	distance = 1.5
+	})
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 Dependencies: https://github.com/mkafrin/PolyZone
 
 ## Updated functionality
-My fork of bt-target includes the option to pass all data through the event to target events, for example:
+My fork of bt-target includes the following options:
+* Pass all data through to the target event in the data table 
+* Add vehicle bone support
+* Disable the ability to aima/attack while in interactive mode
+* Check overall job grade to access the menu 
+* Check individual option job grades 
+
 
 ```lua
 Citizen.CreateThread(function()
@@ -18,11 +24,12 @@ Citizen.CreateThread(function()
                 label = "Coffee",
                 item = "coffee",
                 price = 5,
+                grade = 1,  --This defines the minimum grade of the jobs defined below to access this option
                 anything_else = "You can pass any data through this table",
                 mytable = { name = 'mytable', description = 'including another table'},
             },
         },
-        job = {"all"}
+        job = {["all"] = grade { grade = 0}} -- Allow you to define overall grade requirements to access any option within this interaction
         distance = 2.5
     })
 end)
@@ -55,19 +62,22 @@ Citizen.CreateThread(function()
                 event = "Random 2event",
                 icon = "fas fa-dumpster",
                 label = "Random 2",
+                grade = 1,
             },
             {
                 event = "Random 3event",
                 icon = "fas fa-dumpster",
                 label = "Random 3",
+                grade = 2,
             },
             {
                 event = "Random 4event",
                 icon = "fas fa-dumpster",
                 label = "Random 4",
+                grade = 3,
             },
         },
-        job = {"garbage"}
+        job = {["garbage"] = {grade = 0}}
         distance = 2.5
     })
 
@@ -82,7 +92,7 @@ Citizen.CreateThread(function()
                 label = "Coffee",
             },
         },
-        job = {"all"}
+        job = {["all"] = {grade = 0}}
         distance = 2.5
     })
     
@@ -105,7 +115,7 @@ Citizen.CreateThread(function()
                 label = "Sign Off",
             },
         },
-        job = {"police", "ambulance", "mechanic"},
+        job = {["police"] = {grade = 0}, ["ambulance"] = { grade = 0}, ["mechanic"] = {grade =0 }},
         distance = 1.5
     })
 end)

--- a/bt-target/client/main.lua
+++ b/bt-target/client/main.lua
@@ -59,33 +59,36 @@ function playerTargetEnable()
             if GetEntityType(entity) ~= 0 then
                 for _, model in pairs(Models) do
                     if _ == GetEntityModel(entity) then
-                        for k , v in ipairs(Models[_]["job"]) do 
-                            if v == "all" or v == PlayerJob.name then
-                                if _ == GetEntityModel(entity) then
-                                    if #(plyCoords - coords) <= Models[_]["distance"] then
-
-                                        success = true
-
-                                        SendNUIMessage({response = "validTarget", data = Models[_]["options"]})
-
-                                        while success and targetActive do
-                                            local plyCoords = GetEntityCoords(GetPlayerPed(-1))
-                                            local hit, coords, entity = RayCastGamePlayCamera(20.0)
-
-                                            DisablePlayerFiring(PlayerPedId(), true)
-
-                                            if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                                SetNuiFocus(true, true)
-                                                SetCursorLocation(0.5, 0.5)
+                        for k , v in pairs(Models[_]["job"]) do
+                            if k == "all" or k == PlayerJob.name then
+                                if v.grade <= PlayerJob.grade then 
+                                    if _ == GetEntityModel(entity) then
+                                        if #(plyCoords - coords) <= Models[_]["distance"] then
+                                            local options = Models[_]["options"]
+                                            local send_options = {}
+                                            for l,b in pairs(options) do 
+                                                if b.grade == nil or b.grade <= PlayerJob.grade then 
+                                                    local slot = #send_options + 1
+                                                    send_options[slot] = b
+                                                end
                                             end
-
-                                            if GetEntityType(entity) == 0 or #(plyCoords - coords) > Models[_]["distance"] then
-                                                success = false
+                                            success = true
+                                            SendNUIMessage({response = "validTarget", data = send_options})
+                                            while success and targetActive do
+                                                local plyCoords = GetEntityCoords(GetPlayerPed(-1))
+                                                local hit, coords, entity = RayCastGamePlayCamera(20.0)
+                                                DisablePlayerFiring(PlayerPedId(), true)
+                                                if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+                                                    SetNuiFocus(true, true)
+                                                    SetCursorLocation(0.5, 0.5)
+                                                end
+                                                if GetEntityType(entity) == 0 or #(plyCoords - coords) > Models[_]["distance"] then
+                                                    success = false
+                                                end
+                                                Citizen.Wait(1)
                                             end
-
-                                            Citizen.Wait(1)
+                                            SendNUIMessage({response = "leftTarget"})
                                         end
-                                        SendNUIMessage({response = "leftTarget"})
                                     end
                                 end
                             end
@@ -101,33 +104,38 @@ function playerTargetEnable()
                     local distanceToBone = GetDistanceBetweenCoords(bonePos, plyCoords, 1)
 
                     if #(bonePos - coords) <= Bones[_]["distance"] then
-                        for k , v in ipairs(Bones[_]["job"]) do
-                            if v == "all" or v == PlayerJob.name then
-                                if #(plyCoords - coords) <= Bones[_]["distance"] then
-                                    success = true
-
-                                    SendNUIMessage({response = "validTarget", data = Bones[_]["options"]})
-
-                                    while success and targetActive do
-                                        local plyCoords = GetEntityCoords(PlayerPedId())
-                                        local hit, coords, entity = RayCastGamePlayCamera(7.0)
-                                        local boneI = GetEntityBoneIndexByName(nearestVehicle, _)
-
-                                        DisablePlayerFiring(PlayerPedId(), true)
-
-                                        if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                            SetNuiFocus(true, true)
-                                            SetCursorLocation(0.5, 0.5)
+                        for k , v in pairs(Bones[_]["job"]) do
+                            if k == "all" or k == PlayerJob.name then
+                                if v.grade <= PlayerJob.grade then 
+                                    if #(plyCoords - coords) <= Bones[_]["distance"] then
+                                        local options = Bones[_]["options"]
+                                        local send_options = {}
+                                        for l,b in pairs(options) do 
+                                            if b.grade == nil or b.grade <= PlayerJob.grade then 
+                                                local slot = #send_options + 1
+                                                send_options[slot] = b
+                                            end
                                         end
+                                        success = true
+                                        SendNUIMessage({response = "validTarget", data = send_options})
+                                        while success and targetActive do
+                                            local plyCoords = GetEntityCoords(PlayerPedId())
+                                            local hit, coords, entity = RayCastGamePlayCamera(7.0)
+                                            local boneI = GetEntityBoneIndexByName(nearestVehicle, _)
+                                            DisablePlayerFiring(PlayerPedId(), true)
 
-                                        if #(plyCoords - coords) > Bones[_]["distance"] then
-                                            success = false
+                                            if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+                                                SetNuiFocus(true, true)
+                                                SetCursorLocation(0.5, 0.5)
+                                            end
+                                            if #(plyCoords - coords) > Bones[_]["distance"] then
+                                                success = false
+                                            end
+                                            Citizen.Wait(1)
                                         end
-
-                                        Citizen.Wait(1)
+                                        success = false
+                                        SendNUIMessage({response = "leftTarget"})
                                     end
-                                    success = false
-                                    SendNUIMessage({response = "leftTarget"})
                                 end
                             end
                         end
@@ -137,33 +145,38 @@ function playerTargetEnable()
 
             for _, zone in pairs(Zones) do
                 if Zones[_]:isPointInside(coords) then
-                    for k , v in ipairs(Zones[_]["targetoptions"]["job"]) do 
-                        if v == "all" or v == PlayerJob.name then
-                            if #(plyCoords - Zones[_].center) <= zone["targetoptions"]["distance"] then
-
-                                success = true
-
-                                SendNUIMessage({response = "validTarget", data = Zones[_]["targetoptions"]["options"]})
-                                while success and targetActive do
-                                    local plyCoords = GetEntityCoords(GetPlayerPed(-1))
-                                    local hit, coords, entity = RayCastGamePlayCamera(20.0)
-
-                                    DisablePlayerFiring(PlayerPedId(), true)
-
-                                    if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                        SetNuiFocus(true, true)
-                                        SetCursorLocation(0.5, 0.5)
-                                    elseif not Zones[_]:isPointInside(coords) or #(vector3(Zones[_].center.x, Zones[_].center.y, Zones[_].center.z) - plyCoords) > zone.targetoptions.distance then
+                    for k , v in pairs(Zones[_]["targetoptions"]["job"]) do 
+                        if k == "all" or k == PlayerJob.name then
+                            if v.grade <= PlayerJob.grade then 
+                                if #(plyCoords - Zones[_].center) <= zone["targetoptions"]["distance"] then
+                                    local options = Zones[_]["targetoptions"]["options"]
+                                    local send_options = {}
+                                    for l,b in pairs(options) do 
+                                        if b.grade == nil or b.grade <= PlayerJob.grade then 
+                                            local slot = #send_options + 1
+                                            send_options[slot] = b
+                                        end
                                     end
+                                    success = true
+                                    SendNUIMessage({response = "validTarget", data = send_options})
+                                    while success and targetActive do
+                                        local plyCoords = GetEntityCoords(GetPlayerPed(-1))
+                                        local hit, coords, entity = RayCastGamePlayCamera(20.0)
+                                        DisablePlayerFiring(PlayerPedId(), true)
+                                        if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+                                            SetNuiFocus(true, true)
+                                            SetCursorLocation(0.5, 0.5)
+                                        elseif not Zones[_]:isPointInside(coords) or #(vector3(Zones[_].center.x, Zones[_].center.y, Zones[_].center.z) - plyCoords) > zone.targetoptions.distance then
+                                        end
         
-                                    if not Zones[_]:isPointInside(coords) or #(plyCoords - Zones[_].center) > zone.targetoptions.distance then
-                                        success = false
-                                    end
-        
+                                        if not Zones[_]:isPointInside(coords) or #(plyCoords - Zones[_].center) > zone.targetoptions.distance then
+                                            success = false
+                                        end
 
-                                    Citizen.Wait(1)
+                                        Citizen.Wait(1)
+                                    end
+                                    SendNUIMessage({response = "leftTarget"})
                                 end
-                                SendNUIMessage({response = "leftTarget"})
                             end
                         end
                     end

--- a/bt-target/client/main.lua
+++ b/bt-target/client/main.lua
@@ -1,314 +1,389 @@
+local Entities = {}
 local Models = {}
 local Zones = {}
 local Bones = {}
 
-
 Citizen.CreateThread(function()
-    RegisterKeyMapping("+playerTarget", "Player Targeting", "keyboard", "LMENU") --Removed Bind System and added standalone version
-    RegisterCommand('+playerTarget', playerTargetEnable, false)
-    RegisterCommand('-playerTarget', playerTargetDisable, false)
-    TriggerEvent("chat:removeSuggestion", "/+playerTarget")
-    TriggerEvent("chat:removeSuggestion", "/-playerTarget")
+	RegisterKeyMapping("+playerTarget", "Player Targeting", "keyboard", "LMENU") --Removed Bind System and added standalone version
+	RegisterCommand('+playerTarget', playerTargetEnable, false)
+	RegisterCommand('-playerTarget', playerTargetDisable, false)
+	TriggerEvent("chat:removeSuggestion", "/+playerTarget")
+	TriggerEvent("chat:removeSuggestion", "/-playerTarget")
 end)
 
-if Config.ESX then
-    Citizen.CreateThread(function()
-        while ESX == nil do
-            TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-            Citizen.Wait(0)
-        end
+RegisterNetEvent('esx:playerLoaded')
+AddEventHandler('esx:playerLoaded', function(playerData)
+	ESX.PlayerData.job = playerData.job
+end)
 
-        RegisterNetEvent('esx:playerLoaded')
-        AddEventHandler('esx:playerLoaded', function(playerData)
-            PlayerJob = playerData.job
-        end)
-
-        RegisterNetEvent('esx:setJob')
-		AddEventHandler('esx:setJob', function(job)
-		    PlayerJob = job
-		end)
-    end)
-else
-    PlayerJob = Config.NonEsxJob()
-end
+RegisterNetEvent('esx:setJob')
+AddEventHandler('esx:setJob', function(job)
+	ESX.PlayerData.job = job
+end)
 
 function playerTargetEnable()
-    if success then return end
-    if IsPedArmed(PlayerPedId(), 6) then return end
-    local nearestVehicle = GetNearestVehicle()
-    targetActive = true
-    SendNUIMessage({response = "openTarget"})
+	if success then return end
+	if IsPedArmed(PlayerPedId(), 6) then return end
+	targetActive = true
+	SetInterval(1, 5, function()
+		DisableControlAction(0,24,true) -- disable attack
+		DisableControlAction(0,25,true) -- disable aim
+		DisableControlAction(0,47,true) -- disable weapon
+		DisableControlAction(0,58,true) -- disable weapon
+		DisableControlAction(0,263,true) -- disable melee
+		DisableControlAction(0,264,true) -- disable melee
+		DisableControlAction(0,257,true) -- disable melee
+		DisableControlAction(0,140,true) -- disable melee
+		DisableControlAction(0,141,true) -- disable melee
+		DisableControlAction(0,142,true) -- disable melee
+		DisableControlAction(0,143,true) -- disable melee
+	end)
+	SendNUIMessage({response = "openTarget"})
 
 
 
-    while targetActive do
-        local plyCoords = GetEntityCoords(GetPlayerPed(-1))
-        local hit, coords, entity = RayCastGamePlayCamera(20.0)
-        DisableControlAction(0,24,true) -- disable attack
-        DisableControlAction(0,25,true) -- disable aim
-        DisableControlAction(0,47,true) -- disable weapon
-        DisableControlAction(0,58,true) -- disable weapon
-        DisableControlAction(0,263,true) -- disable melee
-        DisableControlAction(0,264,true) -- disable melee
-        DisableControlAction(0,257,true) -- disable melee
-        DisableControlAction(0,140,true) -- disable melee
-        DisableControlAction(0,141,true) -- disable melee
-        DisableControlAction(0,142,true) -- disable melee
-        DisableControlAction(0,143,true) -- disable melee
-        if hit == 1 then
-            if GetEntityType(entity) ~= 0 then
-                for _, model in pairs(Models) do
-                    if _ == GetEntityModel(entity) then
-                        for k , v in pairs(Models[_]["job"]) do
-                            if k == "all" or k == PlayerJob.name then
-                                if v.grade <= PlayerJob.grade then 
-                                    if _ == GetEntityModel(entity) then
-                                        if #(plyCoords - coords) <= Models[_]["distance"] then
-                                            local options = Models[_]["options"]
-                                            local send_options = {}
-                                            for l,b in pairs(options) do 
-                                                if b.grade == nil or b.grade <= PlayerJob.grade then 
-                                                    local slot = #send_options + 1
-                                                    send_options[slot] = b
-                                                end
-                                            end
-                                            success = true
-                                            SendNUIMessage({response = "validTarget", data = send_options})
-                                            while success and targetActive do
-                                                local plyCoords = GetEntityCoords(GetPlayerPed(-1))
-                                                local hit, coords, entity = RayCastGamePlayCamera(20.0)
-                                                DisablePlayerFiring(PlayerPedId(), true)
-                                                if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                                    SetNuiFocus(true, true)
-                                                    SetCursorLocation(0.5, 0.5)
-                                                end
-                                                if GetEntityType(entity) == 0 or #(plyCoords - coords) > Models[_]["distance"] then
-                                                    success = false
-                                                end
-                                                Citizen.Wait(1)
-                                            end
-                                            SendNUIMessage({response = "leftTarget"})
-                                        end
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-			
-            if nearestVehicle then
-                for _, bone in pairs(Bones) do
-                    local boneIndex = GetEntityBoneIndexByName(nearestVehicle, _)
-                    local bonePos = GetWorldPositionOfEntityBone(nearestVehicle, boneIndex)
-                    local distanceToBone = GetDistanceBetweenCoords(bonePos, plyCoords, 1)
+	while targetActive do
 
-                    if #(bonePos - coords) <= Bones[_]["distance"] then
-                        for k , v in pairs(Bones[_]["job"]) do
-                            if k == "all" or k == PlayerJob.name then
-                                if v.grade <= PlayerJob.grade then 
-                                    if #(plyCoords - coords) <= Bones[_]["distance"] then
-                                        local options = Bones[_]["options"]
-                                        local send_options = {}
-                                        for l,b in pairs(options) do 
-                                            if b.grade == nil or b.grade <= PlayerJob.grade then 
-                                                local slot = #send_options + 1
-                                                send_options[slot] = b
-                                            end
-                                        end
-                                        success = true
-                                        SendNUIMessage({response = "validTarget", data = send_options})
-                                        while success and targetActive do
-                                            local plyCoords = GetEntityCoords(PlayerPedId())
-                                            local hit, coords, entity = RayCastGamePlayCamera(7.0)
-                                            local boneI = GetEntityBoneIndexByName(nearestVehicle, _)
-                                            DisablePlayerFiring(PlayerPedId(), true)
+		local plyCoords = GetEntityCoords(PlayerPedId())
+		local hit, coords, entity = RayCastGamePlayCamera(20.0)
+		if hit == 1 then
 
-                                            if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                                SetNuiFocus(true, true)
-                                                SetCursorLocation(0.5, 0.5)
-                                            end
-                                            if #(plyCoords - coords) > Bones[_]["distance"] then
-                                                success = false
-                                            end
-                                            Citizen.Wait(1)
-                                        end
-                                        success = false
-                                        SendNUIMessage({response = "leftTarget"})
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
+			if GetEntityType(entity) ~= 0 then
 
-            for _, zone in pairs(Zones) do
-                if Zones[_]:isPointInside(coords) then
-                    for k , v in pairs(Zones[_]["targetoptions"]["job"]) do 
-                        if k == "all" or k == PlayerJob.name then
-                            if v.grade <= PlayerJob.grade then 
-                                if #(plyCoords - Zones[_].center) <= zone["targetoptions"]["distance"] then
-                                    local options = Zones[_]["targetoptions"]["options"]
-                                    local send_options = {}
-                                    for l,b in pairs(options) do 
-                                        if b.grade == nil or b.grade <= PlayerJob.grade then 
-                                            local slot = #send_options + 1
-                                            send_options[slot] = b
-                                        end
-                                    end
-                                    success = true
-                                    SendNUIMessage({response = "validTarget", data = send_options})
-                                    while success and targetActive do
-                                        local plyCoords = GetEntityCoords(GetPlayerPed(-1))
-                                        local hit, coords, entity = RayCastGamePlayCamera(20.0)
-                                        DisablePlayerFiring(PlayerPedId(), true)
-                                        if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
-                                            SetNuiFocus(true, true)
-                                            SetCursorLocation(0.5, 0.5)
-                                        elseif not Zones[_]:isPointInside(coords) or #(vector3(Zones[_].center.x, Zones[_].center.y, Zones[_].center.z) - plyCoords) > zone.targetoptions.distance then
-                                        end
-        
-                                        if not Zones[_]:isPointInside(coords) or #(plyCoords - Zones[_].center) > zone.targetoptions.distance then
-                                            success = false
-                                        end
+				for _, entityData in pairs(Entities) do
+					print()
+					if NetworkGetEntityIsNetworked(entity) ==1 and _ == NetworkGetNetworkIdFromEntity(entity) then
+						if #(plyCoords - coords) <= Entities[_]["distance"] then
+							local options = Entities[_]["options"]
+							local send_options = {}
+							for l,b in pairs(options) do 
+								if (b.job == nil or b.job == ESX.PlayerData.job.name or b.job[ESX.PlayerData.job.name]) and (b.job == nil or b.job[ESX.PlayerData.job.name] == nil or b.job[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade) then 
+									if (b.required_item == nil) or (b.required_item and exports['linden_inventory']:CountItems(b.required_item)[b.required_item] > 0) then 
+										if b.owner and b.owner == NetworkGetNetworkIdFromEntity(PlayerPedId()) then
+											if b.canInteract == nil or b.canInteract() then 
+												local slot = #send_options + 1
+												send_options[slot] = b
+												send_options[slot].entity = entity
+											end
+										end
+									end
+								end
+							end
+							success = true
+							if success and #send_options > 0 then 
+								SendNUIMessage({response = "validTarget", data = send_options})
+								while success and targetActive do
+									local plyCoords = GetEntityCoords(PlayerPedId())
+									local hit, coords, entity = RayCastGamePlayCamera(20.0)
+									DisablePlayerFiring(PlayerPedId(), true)
+									if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+										SetNuiFocus(true, true)
+										SetCursorLocation(0.5, 0.5)
+									end
+									if GetEntityType(entity) == 0 or #(plyCoords - coords) > Entities[_]["distance"] then
+										success = false
+									end
+									Citizen.Wait(1)
+								end
+							end
+							SendNUIMessage({response = "leftTarget"})
+						end
+					end
+				end
 
-                                        Citizen.Wait(1)
-                                    end
-                                    SendNUIMessage({response = "leftTarget"})
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-        Citizen.Wait(5)
-    end
+				for _, model in pairs(Models) do
+					if _ == GetEntityModel(entity) then
+						if #(plyCoords - coords) <= Models[_]["distance"] then
+							local options = Models[_]["options"]
+							local send_options = {}
+							for l,b in pairs(options) do 
+								if (b.job == nil or b.job == ESX.PlayerData.job.name or b.job[ESX.PlayerData.job.name]) and (b.job == nil or b.job[ESX.PlayerData.job.name] == nil or b.job[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade) then 
+									if (b.required_item == nil) or (b.required_item and exports['linden_inventory']:CountItems(b.required_item)[b.required_item] > 0) then 
+										if b.canInteract == nil or b.canInteract() then 
+											local slot = #send_options + 1
+											send_options[slot] = b
+											send_options[slot].entity = entity
+										end
+									end
+								end
+							end
+							success = true
+							if success and #send_options > 0 then 
+								SendNUIMessage({response = "validTarget", data = send_options})
+							
+								while success and targetActive do
+									local plyCoords = GetEntityCoords(PlayerPedId())
+									local hit, coords, entity = RayCastGamePlayCamera(20.0)
+									DisablePlayerFiring(PlayerPedId(), true)
+									if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+										SetNuiFocus(true, true)
+										SetCursorLocation(0.5, 0.5)
+									end
+									if GetEntityType(entity) == 0 or #(plyCoords - coords) > Models[_]["distance"] then
+										success = false
+									end
+									Citizen.Wait(1)
+								end
+								SendNUIMessage({response = "leftTarget"})
+							end 
+						end
+					end
+				end
+			end
+
+			if IsEntityAVehicle(entity) then 
+				local bone, hitDistanceToBone, boneIndex, bonePos = FindNearestVehicleBoneToRayCast(entity,coords,hit)
+				local distanceToBone = #(bonePos - plyCoords)
+				if (bone ~= nil and Bones[bone] ~= nil and distanceToBone ~= nil) and distanceToBone <= Bones[bone]["distance"] then 
+					local options = Bones[bone]["options"]
+					local send_options = {}
+					for l,b in pairs(options) do 
+						if (b.job == nil or b.job == ESX.PlayerData.job.name or b.job[ESX.PlayerData.job.name]) and (b.job == nil or b.job[ESX.PlayerData.job.name] == nil or b.job[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade) then 
+							if (b.required_item == nil) or (b.required_item and exports['linden_inventory']:CountItems(b.required_item)[b.required_item] > 0) then 
+								if b.canInteract == nil or b.canInteract() then 
+									local slot = #send_options + 1
+									send_options[slot] = b
+									send_options[slot].entity = entity
+								end
+							end
+						end
+					end
+					success = true
+					if success and #send_options > 0 then 
+						SendNUIMessage({response = "validTarget", data = send_options})
+						while success and targetActive do
+							local plyCoords = GetEntityCoords(PlayerPedId())
+							local hit, coords, entity = RayCastGamePlayCamera(20.0)
+							local newbone, hitDistanceToBone, boneIndex, bonePos = FindNearestVehicleBoneToRayCast(entity,coords,hit)
+							DisablePlayerFiring(PlayerPedId(), true)
+							if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+								SetNuiFocus(true, true)
+								SetCursorLocation(0.5, 0.5)
+							end
+							if #(plyCoords - bonePos) > Bones[bone]["distance"] or (not IsEntityAVehicle(entity)) or newbone ~= bone or not DoesEntityExist(entity) or not hit then
+								success = false
+							end
+							Citizen.Wait(1)
+						end
+					end
+					SendNUIMessage({response = "leftTarget"})
+				end 
+			end
+
+			for _, zone in pairs(Zones) do
+				if Zones[_]:isPointInside(coords) then
+					if #(plyCoords - Zones[_].center) <= zone["targetoptions"]["distance"] then
+						local options = Zones[_]["targetoptions"]["options"]
+						local send_options = {}
+						for l,b in pairs(options) do 
+							if (b.job == nil or b.job == ESX.PlayerData.job.name or b.job[ESX.PlayerData.job.name]) and (b.job == nil or b.job[ESX.PlayerData.job.name] == nil or b.job[ESX.PlayerData.job.name] <= ESX.PlayerData.job.grade) then 
+								if (b.required_item == nil) or (b.required_item and exports['linden_inventory']:CountItems(b.required_item)[b.required_item] > 0) then 
+									if b.canInteract == nil or b.canInteract() then 
+										local slot = #send_options + 1
+										send_options[slot] = b
+										send_options[slot].entity = entity
+									end
+								end
+							end
+						end
+						success = true
+						if success and #send_options > 0 then 
+							SendNUIMessage({response = "validTarget", data = send_options})
+							while success and targetActive do
+								local plyCoords = GetEntityCoords(PlayerPedId())
+								local hit, coords, entity = RayCastGamePlayCamera(20.0)
+								DisablePlayerFiring(PlayerPedId(), true)
+								if (IsControlJustReleased(0, 24) or IsDisabledControlJustReleased(0, 24)) then
+									SetNuiFocus(true, true)
+									SetCursorLocation(0.5, 0.5)
+								elseif not Zones[_]:isPointInside(coords) or #(vector3(Zones[_].center.x, Zones[_].center.y, Zones[_].center.z) - plyCoords) > zone.targetoptions.distance then
+								end
+
+								if not Zones[_]:isPointInside(coords) or #(plyCoords - Zones[_].center) > zone.targetoptions.distance then
+									success = false
+								end
+
+								Citizen.Wait(1)
+							end
+						end
+						SendNUIMessage({response = "leftTarget"})
+					end
+				end
+			end
+		end
+		
+		Citizen.Wait(1)
+	end
+	SendNUIMessage({response = "closeTarget"})
+	success = false 
+	targetActive = false
+	ClearInterval(1)
 end
 
 
 
 
 function playerTargetDisable()
-    if success then return end
+	if targetActive then
 
-    success = false
+	success = false
+	targetActive = false
+	ClearInterval(1)
 
-    targetActive = false
-
-    SendNUIMessage({response = "closeTarget"})
+	SendNUIMessage({response = "closeTarget"})
+	end
 end
 
 --NUI CALL BACKS
 
 RegisterNUICallback('selectTarget', function(data, cb)
-    SetNuiFocus(false, false)
+	SetNuiFocus(false, false)
 
-    success = false
+	success = false
 
-    targetActive = false
+	targetActive = false
 
-    TriggerEvent(data.event,data)
+	if data.server then 
+		TriggerServerEvent(data.event,data)
+	else
+		TriggerEvent(data.event,data)
+	end
 
 end)
 
 RegisterNUICallback('closeTarget', function(data, cb)
-    SetNuiFocus(false, false)
+	SetNuiFocus(false, false)
 
-    success = false
+	success = false
 
-    targetActive = false
+	targetActive = false
 end)
+
+
+function FindNearestVehicleBoneToRayCast()
+	local hit, coords, entity = RayCastGamePlayCamera(20.0)
+	local pos = GetEntityCoords(PlayerPedId(),true)
+	local to = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 20.0,0.0)
+	local lowestDistance = 9999
+	local lowestDistanceBone = nil
+	local lowestDistancePosition = nil
+	local lowestBoneIndex = nil
+	if hit then 
+		if DoesEntityExist(entity) and IsEntityAVehicle(entity) then 
+			for k,v in pairs(Config.VehicleBones) do 
+				local bone = GetEntityBoneIndexByName(entity,v)
+				local from = coords
+				local to = GetWorldPositionOfEntityBone(entity,bone)
+				local dist = #(from - to)
+				if dist ~= -1 then 
+					--print(dist)
+					if dist < lowestDistance then 
+						lowestDistance = dist 
+						lowestDistanceBone = v
+						lowestDistancePosition = to
+						lowestBoneIndex = bone
+					end
+				end
+			end 
+		end 
+	end
+	--print("Lowest distance was "..lowestDistance.." - "..lowestDistanceBone)
+	return lowestDistanceBone, lowestDistance, lowestBoneIndex, lowestDistancePosition
+end 
+
 
 --Functions from https://forum.cfx.re/t/get-camera-coordinates/183555/14
 
 function RotationToDirection(rotation)
-    local adjustedRotation =
-    {
-        x = (math.pi / 180) * rotation.x,
-        y = (math.pi / 180) * rotation.y,
-        z = (math.pi / 180) * rotation.z
-    }
-    local direction =
-    {
-        x = -math.sin(adjustedRotation.z) * math.abs(math.cos(adjustedRotation.x)),
-        y = math.cos(adjustedRotation.z) * math.abs(math.cos(adjustedRotation.x)),
-        z = math.sin(adjustedRotation.x)
-    }
-    return direction
+	local adjustedRotation =
+	{
+		x = (math.pi / 180) * rotation.x,
+		y = (math.pi / 180) * rotation.y,
+		z = (math.pi / 180) * rotation.z
+	}
+	local direction =
+	{
+		x = -math.sin(adjustedRotation.z) * math.abs(math.cos(adjustedRotation.x)),
+		y = math.cos(adjustedRotation.z) * math.abs(math.cos(adjustedRotation.x)),
+		z = math.sin(adjustedRotation.x)
+	}
+	return direction
 end
 
 function RayCastGamePlayCamera(distance)
-    local cameraRotation = GetGameplayCamRot()
-    local cameraCoord = GetGameplayCamCoord()
-    local direction = RotationToDirection(cameraRotation)
-    local destination =
-    {
-        x = cameraCoord.x + direction.x * distance,
-        y = cameraCoord.y + direction.y * distance,
-        z = cameraCoord.z + direction.z * distance
-    }
-    local a, b, c, d, e = GetShapeTestResult(StartShapeTestRay(cameraCoord.x, cameraCoord.y, cameraCoord.z, destination.x, destination.y, destination.z, -1, PlayerPedId(), 0))
-    return b, c, e
+	local cameraRotation = GetGameplayCamRot()
+	local cameraCoord = GetGameplayCamCoord()
+	local direction = RotationToDirection(cameraRotation)
+	local destination =
+	{
+		x = cameraCoord.x + direction.x * distance,
+		y = cameraCoord.y + direction.y * distance,
+		z = cameraCoord.z + direction.z * distance
+	}
+	local a, b, c, d, e = GetShapeTestResult(StartShapeTestRay(cameraCoord.x, cameraCoord.y, cameraCoord.z, destination.x, destination.y, destination.z, -1, PlayerPedId(), 0))
+	return b, c, e
 end
 
 function GetNearestVehicle()
-    local playerPed = GetPlayerPed(-1)
-    local playerCoords = GetEntityCoords(playerPed)
-    if not (playerCoords and playerPed) then
-        return
-    end
+	local playerPed = PlayerPedId()
+	local playerCoords = GetEntityCoords(playerPed)
+	if not (playerCoords and playerPed) then
+		return
+	end
 
-    local pointB = GetEntityForwardVector(playerPed) * 0.001 + playerCoords
+	local pointB = GetEntityForwardVector(playerPed) * 0.001 + playerCoords
 
-    local shapeTest = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z, pointB.x, pointB.y, pointB.z, 1.0, 10, playerPed, 7)
-    local _, hit, _, _, entity = GetShapeTestResult(shapeTest)
+	local shapeTest = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z, pointB.x, pointB.y, pointB.z, 1.0, 10, playerPed, 7)
+	local _, hit, _, _, entity = GetShapeTestResult(shapeTest)
 
-    return (hit == 1 and IsEntityAVehicle(entity)) and entity or false
+	return (hit == 1 and IsEntityAVehicle(entity)) and entity or false
 end
 
 --Exports
 
 function AddCircleZone(name, center, radius, options, targetoptions)
-    Zones[name] = CircleZone:Create(center, radius, options)
-    Zones[name].targetoptions = targetoptions
+	Zones[name] = CircleZone:Create(center, radius, options)
+	Zones[name].targetoptions = targetoptions
 end
 
 function AddBoxZone(name, center, length, width, options, targetoptions)
-    Zones[name] = BoxZone:Create(center, length, width, options)
-    Zones[name].targetoptions = targetoptions
+	Zones[name] = BoxZone:Create(center, length, width, options)
+	Zones[name].targetoptions = targetoptions
 end
 
 function AddPolyzone(name, points, options, targetoptions)
-    Zones[name] = PolyZone:Create(points, options)
-    Zones[name].targetoptions = targetoptions
+	Zones[name] = PolyZone:Create(points, options)
+	Zones[name].targetoptions = targetoptions
 end
 
 function AddTargetModel(models, parameteres)
-    for _, model in pairs(models) do
-        Models[model] = parameteres
-    end
+	for _, model in pairs(models) do
+		Models[model] = parameteres
+	end
+end
+
+function AddTargetEntity(entity, parameteres)
+	Entities[entity] = parameteres
 end
 
 function AddTargetBone(bones, parameteres)
-    for _, bone in pairs(bones) do
-        Bones[bone] = parameteres
-    end
+	for _, bone in pairs(bones) do
+		Bones[bone] = parameteres
+	end
 end
 
 function AddEntityZone(name, entity, options, targetoptions)
-    Zones[name] = EntityZone:Create(entity, options)
-    Zones[name].targetoptions = targetoptions
-    end
+	Zones[name] = EntityZone:Create(entity, options)
+	Zones[name].targetoptions = targetoptions
+	end
 
 function RemoveZone(name)
-    if not Zones[name] then return end
-    if Zones[name].destroy then
-        Zones[name]:destroy()
-    end
+	if not Zones[name] then return end
+	if Zones[name].destroy then
+		Zones[name]:destroy()
+	end
 
-    Zones[name] = nil
+	Zones[name] = nil
 end
 
 exports("AddCircleZone", AddCircleZone)
@@ -318,6 +393,8 @@ exports("AddBoxZone", AddBoxZone)
 exports("AddPolyzone", AddPolyzone)
 
 exports("AddTargetModel", AddTargetModel)
+
+exports("AddTargetEntity", AddTargetEntity)
 
 exports("AddTargetBone", AddTargetBone)
 

--- a/bt-target/config.lua
+++ b/bt-target/config.lua
@@ -1,15 +1,49 @@
 Config = {}
 
-Config.ESX = true
-
-
 -- Return an object in the format
 -- {
---     name = job name
+--	 name = job name
 -- }
 
-Config.NonEsxJob = function()
-    local PlayerJob = {}
-
-    return PlayerJob
-end
+Config.VehicleBones = {
+'chassis',  
+'windscreen',  
+'seat_pside_r',  
+'seat_dside_r',  
+'bodyshell',  
+'suspension_lm',  
+'suspension_lr',  
+'platelight',  
+'attach_female',  
+'attach_male',  
+'bonnet',  
+'boot',  
+'chassis_dummy',	
+'chassis_Control',	
+'door_dside_f',	
+'door_dside_r',	
+'door_pside_f',	
+'door_pside_r',	
+'Gun_GripR',  
+'windscreen_f',  
+'platelight',	
+'VFX_Emitter',  
+'window_lf',	
+'window_lr',	
+'window_rf',	
+'window_rr',	
+'engine',	
+'gun_ammo',  
+'ROPE_ATTATCH',	
+'wheel_lf',
+'wheel_lr',	
+'wheel_rf',	
+'wheel_rr',	
+'exhaust',	
+'overheat',	
+'misc_e',	
+'seat_dside_f',
+'seat_pside_f',
+'Gun_Nuzzle',  
+'seat_r',  
+}

--- a/bt-target/fxmanifest.lua
+++ b/bt-target/fxmanifest.lua
@@ -2,6 +2,8 @@ fx_version 'adamant'
 
 game 'gta5'
 
+version 'noms 0.2'
+
 dependencies {
     "PolyZone"
 }
@@ -9,6 +11,7 @@ dependencies {
 ui_page 'html/index.html'
 
 client_scripts {
+	'@es_extended/imports.lua',
 	'@PolyZone/client.lua',
 	'@PolyZone/BoxZone.lua',
 	'@PolyZone/EntityZone.lua',


### PR DESCRIPTION
## Version noms 0.2
* Added support for networked Entity bt-targets - you can attach a bt-target to a spawned entity and it'll be removed with that entity when it gets deleted, and the target only applies to that specific entity
* Added support for EntityZones - spawn a zone around an entity which can be interacted with 
* Ability to pass any parameters through the bt-target option (see examples)
* Pass the entity interacted with through the event
* Moved job/grade checks to a per-option basis, and made it optional so you don't have to define it (see examples)
* Added a `required_item` check that works with Linden Inventory exports to check if you have an item before showing an option (see examples)
* Added a `canInteract()` function (see examples)